### PR TITLE
Add durable name to durable subscriptions

### DIFF
--- a/messenger/messenger.py
+++ b/messenger/messenger.py
@@ -111,7 +111,9 @@ class Messenger(ABC):
         """
 
     @abstractmethod
-    async def subscribe_durable(self, subject: str, callback: Callable[[bytes], None]):
+    async def subscribe_durable(
+        self, subject: str, callback: Callable[[bytes], None], durable: str
+    ):
         """
         Subscribes to the durable `subject`, and call `callback` with the received content.
         Automatically acknowledges to the subject the take-over of the message.
@@ -119,11 +121,15 @@ class Messenger(ABC):
         Args:
           subject: Subject that the subscriber will observe.
           callback: a Callable function, that the subscriber will call.
+          durable: The name of the durable consumer
         """
 
     @abstractmethod
     async def subscribe_durable_with_ack(
-        self, subject: str, callback: Callable[[bytes, Callable[[], bool]], None]
+        self,
+        subject: str,
+        callback: Callable[[bytes, Callable[[], bool]], None],
+        durable: str
     ):
         """
         Subscribes to the durable `subject`, and call `callback` with the received content.
@@ -133,4 +139,5 @@ class Messenger(ABC):
         Args:
           subject: Subject that the subscriber will observe.
           callback: a Callable function, that the subscriber will call.
+          durable: The name of the durable consumer
         """

--- a/messenger/messenger.py
+++ b/messenger/messenger.py
@@ -129,7 +129,7 @@ class Messenger(ABC):
         self,
         subject: str,
         callback: Callable[[bytes, Callable[[], bool]], None],
-        durable: str
+        durable: str,
     ):
         """
         Subscribes to the durable `subject`, and call `callback` with the received content.

--- a/mpa/consumer.py
+++ b/mpa/consumer.py
@@ -76,7 +76,7 @@ class MessageConsumerActor:
             self.subscriber = await self.messenger.subscribe_durable_with_ack(
                 self.inbound_subject,
                 actor_fun_wrapper(self.actor_function),
-                self.durable
+                self.durable,
             )
         else:
             self.subscriber = await self.messenger.subscribe(

--- a/mpa/consumer.py
+++ b/mpa/consumer.py
@@ -19,7 +19,7 @@ class MessageConsumerActor:
         messenger: Messenger,
         inbound_subject: str,
         actor_function: Callable[[bytes, dict], tuple[bytes, dict]],
-        durable=True,
+        durable: str = None,
         _logger=logger,
     ):
         """
@@ -74,7 +74,9 @@ class MessageConsumerActor:
 
         if self.durable:
             self.subscriber = await self.messenger.subscribe_durable_with_ack(
-                self.inbound_subject, actor_fun_wrapper(self.actor_function)
+                self.inbound_subject,
+                actor_fun_wrapper(self.actor_function),
+                self.durable
             )
         else:
             self.subscriber = await self.messenger.subscribe(

--- a/mpa/processor.py
+++ b/mpa/processor.py
@@ -93,7 +93,7 @@ class MessageProcessorActor:
 
         if self.durable_in:
             self.subscriber = await self.messenger.subscribe_durable_with_ack(
-                self.inbound_subject, actor_function_wrapper
+                self.inbound_subject, actor_function_wrapper, self.durable_in
             )
         else:
             self.subscriber = await self.messenger.subscribe(

--- a/mpa/tests/test_consumer.py
+++ b/mpa/tests/test_consumer.py
@@ -44,7 +44,6 @@ class ConsumerMPATestCase(unittest.TestCase):
                 Messenger(URL, logger, name=CONSUMER_MPA_CLIENT_ID),
                 INBOUND_TOPIC,
                 actor_function,
-                durable=False,
             )
             await consumer_actor.open()
 
@@ -90,7 +89,7 @@ class ConsumerMPATestCase(unittest.TestCase):
                 Messenger(URL, logger, name=CONSUMER_MPA_CLIENT_ID),
                 DURABLE_INBOUND_TOPIC,
                 actor_function,
-                durable=True,
+                durable="testconsumer",
             )
             await consumer_actor.open()
 

--- a/mpa/tests/test_processor.py
+++ b/mpa/tests/test_processor.py
@@ -107,7 +107,9 @@ class ProcessorMPATestCase(unittest.TestCase):
             consumer = Messenger(URL, logger, name=CONSUMER_CLIENT_ID)
             await consumer.open()
             await consumer.subscribe_durable(
-                DURABLE_OUTBOUND_PROC_TOPIC, callback=consumer_callback
+                DURABLE_OUTBOUND_PROC_TOPIC,
+                callback=consumer_callback,
+                durable="testprocessor",
             )
 
             logger.debug("Setup the processor actor")
@@ -134,8 +136,8 @@ class ProcessorMPATestCase(unittest.TestCase):
                 DURABLE_INBOUND_PROC_TOPIC,
                 DURABLE_OUTBOUND_PROC_TOPIC,
                 actor_function,
-                durable_in=True,
-                durable_out=True,
+                durable_in="durable-in",
+                durable_out="durable-out",
             )
             await processor_actor.open()
 

--- a/mpa/tests/test_producer.py
+++ b/mpa/tests/test_producer.py
@@ -142,7 +142,9 @@ class ProducerMPATestCase(unittest.TestCase):
             consumer = Messenger(URL, logger, name=CONSUMER_CLIENT_ID)
             await consumer.open()
             await consumer.subscribe_durable(
-                DURABLE_OUTBOUND_TOPIC, callback=consumer_callback
+                DURABLE_OUTBOUND_TOPIC,
+                callback=consumer_callback,
+                durable="testproducer",
             )
 
             logger.debug("Setup the producer actor")

--- a/nats_messenger/messenger.py
+++ b/nats_messenger/messenger.py
@@ -345,10 +345,7 @@ class Messenger(messenger.Messenger):
                 self.logger.debug(f"message {msg}, is acknowledged")
 
         subscription = await self.js_conn.subscribe(
-            subject=subject,
-            cb=js_callback,
-            manual_ack=True,
-            durable=durable
+            subject=subject, cb=js_callback, manual_ack=True, durable=durable
         )
         subs = Subscriber(self.js_conn, subscription)
         self.logger.debug(f"Subscribed to {subject} via subscriber: {subs}")

--- a/nats_messenger/messenger.py
+++ b/nats_messenger/messenger.py
@@ -298,7 +298,7 @@ class Messenger(messenger.Messenger):
         await ack_handler(True)
 
     async def subscribe_durable(
-        self, subject: str, callback: Callable[[bytes, dict], None]
+        self, subject: str, callback: Callable[[bytes, dict], None], durable: str
     ):
         """
         Subscribes to the durable `subject`, and call `callback` with the received content.
@@ -307,6 +307,7 @@ class Messenger(messenger.Messenger):
         Args:
           subject: Subject that the subscriber will observe.
           callback: a Callable function, that the subscriber will call.
+          durable: The name of the durable consumer
         """
 
         async def js_callback(msg):
@@ -314,14 +315,14 @@ class Messenger(messenger.Messenger):
             await callback(msg.data, msg.headers)
 
         subscription = await self.js_conn.subscribe(
-            subject, cb=js_callback, manual_ack=False
+            subject, cb=js_callback, manual_ack=False, durable=durable
         )
         subs = Subscriber(self.js_conn, subscription)
         self.logger.debug(f"Subscribed to {subject} via subscriber: {subs}")
         return subs
 
     async def subscribe_durable_with_ack(
-        self, subject: str, callback: Callable[[bytes, dict], None]
+        self, subject: str, callback: Callable[[bytes, dict], None], durable: str
     ):
         """
         Subscribes to the durable `subject`, and call `callback` with the received content.
@@ -330,6 +331,7 @@ class Messenger(messenger.Messenger):
         Args:
           subject: Subject that the subscriber will observe.
           callback: a Callable function, that the subscriber will call.
+          durable: The name of the durable consumer
         """
 
         async def js_callback(msg):
@@ -346,6 +348,7 @@ class Messenger(messenger.Messenger):
             subject=subject,
             cb=js_callback,
             manual_ack=True,
+            durable=durable
         )
         subs = Subscriber(self.js_conn, subscription)
         self.logger.debug(f"Subscribed to {subject} via subscriber: {subs}")

--- a/nats_messenger/tests/test_durable_messenger.py
+++ b/nats_messenger/tests/test_durable_messenger.py
@@ -39,7 +39,7 @@ class MessengerDurableTestCase(unittest.TestCase):
                     callback_called.set_result(None)
 
             subscriber = await messenger.subscribe_durable(
-                TEST_TOPIC_DURABLE, callback=callback
+                TEST_TOPIC_DURABLE, callback=callback, durable="testdurable"
             )
 
             logger.debug("Publish messages")
@@ -84,7 +84,7 @@ class MessengerDurableTestCase(unittest.TestCase):
                     callback_called.set_result(None)
 
             subscriber = await messenger.subscribe_durable(
-                TEST_TOPIC_DURABLE, callback=callback
+                TEST_TOPIC_DURABLE, callback=callback, durable="testdurable"
             )
 
             async def ack_handler(ack):
@@ -141,7 +141,7 @@ class MessengerDurableTestCase(unittest.TestCase):
                 return b"O.K."
 
             subscriber = await messenger.subscribe_durable_with_ack(
-                TEST_TOPIC_DURABLE, callback=callback
+                TEST_TOPIC_DURABLE, callback=callback, durable="testdurable"
             )
 
             logger.debug("Publish messages")


### PR DESCRIPTION
Pull Request
============

#### Scope and implementation details of the PR

To be able to make a subscription connect to an existing consumer created by the nats-cli. The durable name of the consumer has to be added.
