### PR TITLE
Add queue name to rpc server

### DIFF
--- a/messenger/messenger.py
+++ b/messenger/messenger.py
@@ -67,7 +67,12 @@ class Messenger(ABC):
         """
 
     @abstractmethod
-    async def response(self, subject: str, service_fun: Callable[[bytes, dict], None]):
+    async def response(
+        self,
+        subject: str,
+        service_fun: Callable[[bytes, dict], None],
+        queue: Optional[str] = None,
+    ):
         """
         Subscribes to the `subject` topic, and calls the `service_fun` call-back function
         with the inbound messages, then respond with the return value of the `service` function.
@@ -75,6 +80,7 @@ class Messenger(ABC):
         Args:
           subject: Subject that the service as a subscriber will observe.
           service_fun: a Callable function. Its return value will be the response.
+          queue: Name of the queue group
         """
 
     # Functions for durable subjects

--- a/nats_messenger/messenger.py
+++ b/nats_messenger/messenger.py
@@ -224,7 +224,10 @@ class Messenger(messenger.Messenger):
         return response.data, response.headers
 
     async def response(
-        self, subject: str, service_fun: Callable[[bytes, dict], tuple[bytes, dict]]
+        self,
+        subject: str,
+        service_fun: Callable[[bytes, dict], tuple[bytes, dict]],
+        queue: Optional[str] = None,
     ):
         """
         Subscribes to the `subject` topic, and calls the `service_fun` call-back function
@@ -233,6 +236,7 @@ class Messenger(messenger.Messenger):
         Args:
           subject: Subject that the service as a subscriber will observe.
           service_fun: a Callable function. Its return value will be the response.
+          queue: The name of the Nats queue group
         """
 
         async def nats_callback(msg):
@@ -251,7 +255,9 @@ class Messenger(messenger.Messenger):
                 headers=service_response_headers,
             )
 
-        subscription = await self.nats_conn.subscribe(subject=subject, cb=nats_callback)
+        subscription = await self.nats_conn.subscribe(
+            subject=subject, cb=nats_callback, queue=queue
+        )
         subs = Subscriber(self.nats_conn, subscription)
         self.logger.debug(f"Subscribed to {subject} via subscriber: {subs}")
         return subs

--- a/rpc/server.py
+++ b/rpc/server.py
@@ -1,7 +1,7 @@
 """
 The RPCServer class, which represents the unit that can be used an RPC server via messaging.
 """
-from typing import Callable
+from typing import Callable, Optional
 from loguru import logger
 from opentelemetry import trace
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
@@ -40,7 +40,12 @@ class RPCServer:
 
         await self.messenger.close()
 
-    async def listen(self, subject: str, service_fun: Callable[[bytes, dict], bytes]):
+    async def listen(
+        self,
+        subject: str,
+        service_fun: Callable[[bytes, dict], bytes],
+        queue: Optional[str] = None,
+    ):
         """
         Registers a server function to a messaging subject.
         The server's function will be called when an RPCClient sends a request to this subject.
@@ -77,5 +82,5 @@ class RPCServer:
 
         self.logger.debug(f"RPCServer.listen('{subject}')")
         self.subscriber = await self.messenger.response(
-            subject, service_fun_wrapper(service_fun)
+            subject, service_fun_wrapper(service_fun), queue
         )


### PR DESCRIPTION
Pull Request
============

#### Scope and implementation details of the PR

Adding queue group support to RpcServers.

NATS supports a form of load balancing using queue groups, Subscribers register a queue group name. A single subscriber in the group is randomly selected to receive the message.

https://docs.nats.io/nats-concepts/core-nats/queue/queues_walkthrough#see-also

